### PR TITLE
docs: fix README.md commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ Follow the steps below to get this application fully functional and running usin
 In your terminal clone the project and install dependencies:
 
 ```bash
-git clone https://github.com/cal-stytch/stytch-nextjs-app-router-example.git
+git clone https://github.com/stytchauth/stytch-nextjs-app-router-example.git
 cd stytch-nextjs-app-router-example
-# Install dependencies, using pnpm.
-pnpm i
+npx pnpm i
 ```
 
 Next, create `.env.local` file by running the command below which copies the contents of `.env.template`.
@@ -56,7 +55,7 @@ STYTCH_SECRET=secret-test-12345678901234567890abcdabcd
 After completing all the set up steps above the application can be run with the command:
 
 ```bash
-pnpm run dev
+npx pnpm run dev
 ```
 
 The application will be available at [`http://localhost:3000`](http://localhost:3000).


### PR DESCRIPTION
Fixes the README commands such that you can copy-paste them easily.

- Fixes the `git clone` url.
- Removes redundant comment about installing dependencies (see "and install dependencies:")
- Use `npx` given there is no prereq to install `pnpm` globally.

Example errors before fix:

```
zsh: command not found: #
zsh: command not found: pnpm
```

Example output:

```
npx pnpm run dev

> stytch-nextjs-app-router-example@0.1.0 dev /Users/grant/Documents/stytch-test/stytch-nextjs-app-router-example
> next dev

- ready started server on 0.0.0.0:3000, url: http://localhost:3000
- info Loaded env from /Users/grant/Documents/stytch-test/stytch-nextjs-app-router-example/.env.local
- event compiled client and server successfully in 119 ms (20 modules)
- wait compiling...
- event compiled client and server successfully in 59 ms (20 modules)
- wait compiling /page (client and server)...
- event compiled client and server successfully in 2.2s (502 modules)
- ```